### PR TITLE
Remove space from join network command

### DIFF
--- a/docs/lava-node/node-use-installer.md
+++ b/docs/lava-node/node-use-installer.md
@@ -32,7 +32,7 @@ Running the script will:
 3. Sync to latest block
 
 ```bash
-curl -s --location --request GET 'https://get.lavanet.xyz/pnet_join_network' --header 'Authorization: Basic OHRmem1Ta2VuSE1CajhwcDpSRXBhYWZmS2I3TTNQNlBt' > 00_join_network.sh && \ 
+curl -s --location --request GET 'https://get.lavanet.xyz/pnet_join_network' --header 'Authorization: Basic OHRmem1Ta2VuSE1CajhwcDpSRXBhYWZmS2I3TTNQNlBt' > 00_join_network.sh && \
     chmod +x 00_join_network.sh && \
     ./00_join_network.sh production
 ```


### PR DESCRIPTION
Removing the extra space from the command,
If the space is there, the command will still work however, an error will be show saying ": command not found" which might be alarming for users