### PR TITLE
Remove the STDOUT from the systemd unit file

### DIFF
--- a/docs/provider.md
+++ b/docs/provider.md
@@ -251,7 +251,6 @@ Restart=always
 RestartSec=180
 LimitNOFILE=infinity
 LimitNPROC=infinity
-StandardOutput=append:/var/log/lava-provider.log
 [Install]
 WantedBy=multi-user.target" > lava-provider-$NETWORK_NAME-$PROTOCOL.service
 sudo mv lava-provider-$NETWORK_NAME-$PROTOCOL.service /lib/systemd/system/


### PR DESCRIPTION
Change:
- Remove the STDOUT from the systemd unit file Current status:
- The log file for the service is written in a log file Reason for change:
- When writing the service log into a log file, the operators will need to maintain the disk space more frequently, and also that may shut down their node due to disk issues, they can potentially use log rotate, but that is more work and maintenance for them
- Using a service and having the logs managed by journalctl is pretty standard in the industry from the documentations we have seen so far