### PR TITLE
DOCS-17 Fix links broken in component "roadmap"

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -24,9 +24,9 @@ Welcome testers! Thank you for joining the testnet
 
 ### Power up Lava 🌋
 
-[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](validator)
+[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](/validator)
 
-[<RoadmapItem icon="💁" title="Power as a Provider" description="Service chain access, grow the network, earn rewards"/>](provider)
+[<RoadmapItem icon="💁" title="Power as a Provider" description="Service chain access, grow the network, earn rewards"/>](/provider)
 
 
 ### Navigating the Lava - quick links

--- a/docs/lava-blockchain/join-testnet-auto.md
+++ b/docs/lava-blockchain/join-testnet-auto.md
@@ -73,6 +73,6 @@ You are now running a Node in the Lava network 🎉🥳!
 Congrats, happy to have you here 😻 Celebrate it with us on Discord.
 
 When you're ready, start putting the node to use **as a validator**:
-[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](validator-auto#account)
+[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](/validator-auto#account)
 
 :::

--- a/docs/lava-blockchain/join-testnet-manual-cosmovisor.md
+++ b/docs/lava-blockchain/join-testnet-manual-cosmovisor.md
@@ -214,6 +214,6 @@ You are now running a Node in the Lava network 🎉🥳!
 Congrats, happy to have you here 😻 Celebrate it with us on Discord.
 
 When you're ready, start putting the node to use **as a validator**:
-[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](validator-manual#account)
+[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](/validator-manual#account)
 
 :::

--- a/docs/lava-blockchain/join-testnet-manual.md
+++ b/docs/lava-blockchain/join-testnet-manual.md
@@ -241,6 +241,6 @@ You are now running a Node in the Lava network 🎉🥳!
 Congrats, happy to have you here 😻 Celebrate it with us on Discord.
 
 When you're ready, start putting the node to use **as a validator**:
-[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](validator-manual#account)
+[<RoadmapItem icon="🧑‍⚖️" title="Power as a Validator" description="Validate blocks, secure the network, earn rewards"/>](/validator-manual#account)
 
 :::

--- a/docs/lava-blockchain/join-testnet.md
+++ b/docs/lava-blockchain/join-testnet.md
@@ -10,6 +10,6 @@ import RoadmapItem from '@site/src/components/RoadmapItem';
 
 The next pages will cover how to join Lava's testnet, manually or automatically. When you're done, you can continue to start your validator.
 
-[<RoadmapItem icon="🦾" title="Steps to join (with CosmoVisor)" description="Join the network, step by step"/>](testnet-manual-cosmovisor)
-[<RoadmapItem icon="🛠" title="Steps to join (without CosmoVisor)" description="Join the network, step by step"/>](testnet-manual)
+[<RoadmapItem icon="🦾" title="Steps to join (with CosmoVisor)" description="Join the network, step by step"/>](/testnet-manual-cosmovisor)
+[<RoadmapItem icon="🛠" title="Steps to join (without CosmoVisor)" description="Join the network, step by step"/>](/testnet-manual)
 

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -22,5 +22,5 @@ _Note_: This does not cover Delegating LAVA to validators
 
 :::tip Start a validators
 
-[<RoadmapItem icon="🛠" title="Setup steps" description="Step by step guide on getting started"/>](validator-manual)
+[<RoadmapItem icon="🛠" title="Setup steps" description="Step by step guide on getting started"/>](/validator-manual)
 :::


### PR DESCRIPTION
Users reported a problem with broken links.
I can't reproduce them on my machine but trying a blind fix. 
This has a broader fix than what suggested in https://github.com/lavanet/docs/pull/68 (Thanks @0xBigBoss)