### PR TITLE
Add Badges Page(s)

### DIFF
--- a/docs/access-apis/sdk-getting-started.md
+++ b/docs/access-apis/sdk-getting-started.md
@@ -32,7 +32,7 @@ npm init -y
 ### 2. Install the SDK using yarn or NPM
 
 ```bash
-npm i @lavaent/lava-sdk
+npm i @lavanet/lava-sdk
 ```
 
 or

--- a/docs/chains/juno-chain/juno-dev.md
+++ b/docs/chains/juno-chain/juno-dev.md
@@ -1,0 +1,47 @@
+---
+slug: /juno-dev
+title: Getting Juno RPC
+---
+
+# Getting Juno RPC
+
+<hr />
+
+## [Gateway](https://gateway.lavanet.xyz)
+
+<video width="100%" height="100%" controls><source src="/img/chains/junovideodemo.mp4" type="video/mp4"></source></video>
+
+To learn more about using the Lava Gateway visit the [Getting Started guide](https://docs.lavanet.xyz/gateway-getting-started?utm_source=getting-juno-rpc&utm_medium=docs&utm_campaign=juno-pre-grant)
+
+<hr />
+<br />
+
+## [SDK](https://github.com/lavanet/lava-sdk)
+
+
+```jsx
+// Install lavaSDK with the following command:
+// npm i @lavanet/lava-sdk
+const { LavaSDK } = require("@lavanet/lava-sdk")
+
+async function useJunoTestnet() {
+
+    const junoTestnet = await new LavaSDK({
+      privateKey: privKey,
+      chainID: 'JUNT1',
+    });
+
+    const junoBlockResponse =  await junoTestnet.sendRelay({
+    method: "block",
+    params: ["82500"],
+      });
+
+    console.log(junoBlockResponse);
+}
+
+(async () => {
+    await useJunoTestnet();
+  })();
+```
+
+To learn more about our SDK visit the [Getting Started guide](https://docs.lavanet.xyz/sdk-getting-started?utm_source=getting-juno-rpc&utm_medium=docs&utm_campaign=juno-pre-grant)

--- a/docs/chains/juno-chain/juno-node.md
+++ b/docs/chains/juno-chain/juno-node.md
@@ -1,0 +1,27 @@
+---
+slug: /juno-node
+title: Running a Juno RPC Node
+---
+
+# Running a Juno RPC Node
+
+## Install Junod 🚀
+
+Follow the instructions provided in the Juno Network documentation (https://docs.junonetwork.io/validators/getting-setup) to install the Junod software. This software is necessary to run a Juno RPC node.
+
+## Decide Juno Mainnet 🌐  or Testnet 🧪
+
+Choose whether you want to participate in the Juno Mainnet or the Testnet. The Mainnet is the live network where real transactions occur and you will incur real costs, while the Testnet is a separate network for testing and experimentation where you can operate free from concern about incurring costs.
+
+- If you’ve decided to join the Juno Mainnet, refer to the documentation here: https://docs.junonetwork.io/validators/joining-mainnet
+- If you’ve decided to join the Juno Testnet, refer to the documentation here: https://docs.junonetwork.io/validators/joining-the-testnets
+
+Once you’ve done that, all that’s left to do is register on Lava Network!
+
+## Apply to our Provider Incubation Program 📋
+
+In our current state of Testnet, there is an additional stage to pass through before you can become a provider on the Lava Network. Please fill out the [application form](https://lavanet.typeform.com/to/ORi3A13v?utm_source=becoming-a-lava-provider-for-juno&utm_medium=docs&utm_campaign=juno-pre-grant) for our Provider Incubation Program. Feel free to drop a line in our [Discord](https://discord.gg/UxujNZbW) once you’ve completed this step!
+
+## Setup your Provider on Lava Network 🌋
+
+Once you’ve been accepted - to set up your provider on the Lava Network, you can refer to the [provider setup documentation](https://docs.lavanet.xyz/provider-setup?utm_source=running-a-juno-rpc-node&utm_medium=docs&utm_campaign=juno-pre-grant) available elsewhere in our docs. This should provide you with the necessary information to configure and operate your provider node.

--- a/sidebars.js
+++ b/sidebars.js
@@ -101,6 +101,24 @@ const sidebars = {
     },
     {
       type: 'category', 
+      label: 'Chains ⛓️',
+      collapsible: true,
+      collapsed: true,
+      items: [
+        {
+          type: 'category',
+          label: 'Junø',
+          collapsible: true,
+          collapsed: true,
+          items: [
+            'chains/juno-chain/juno-dev',
+            'chains/juno-chain/juno-node'            
+          ]
+        }
+      ]
+    },
+    {
+      type: 'category', 
       label: 'Lava Network',
       collapsible: true,
       collapsed: false,


### PR DESCRIPTION
This adds new pages to the SDK section of the Docs which cover the use of Badge Server for frontend usage.
- add badge-server-temp.md (navigable from sidebar)
- add badge-server.md (hidden/wip)
- edit sidebars.js for navigation purposes

Initially, only a temporary page with COMING SOON is navigable from the docs.
However, the intention is to implement a full guide on how to launch badges server.