### PR TITLE
Add UTM gateway links to sdk pages

### DIFF
--- a/docs/access-apis/badge-server-temp.md
+++ b/docs/access-apis/badge-server-temp.md
@@ -6,7 +6,7 @@ title: Frontend Use
 
 Using Lava SDK on the Frontend without special provisions is inherently unsafe. Private keys from any user can be leaked through the browser. Right now, Lava uses a Badge Server to solve these limitations. The default Badge Server is hosted by Lava for ease of use and onboarding purposes.
 
-You can access it right from the [Lava Gateway!](https://gateway.lavanet.xyz/) However, users who are interested in accomplishing the highest levels of decentralization are encouraged to run their own badge server. 
+You can access it right from the [Lava Gateway!](https://gateway.lavanet.xyz/?utm_source=lava-sdk-docs&utm_medium=docs&utm_campaign=sdk-alpha-launch) However, users who are interested in accomplishing the highest levels of decentralization are encouraged to run their own badge server. 
 
 ## Badges
 

--- a/docs/access-apis/sdk-prerequisites.md
+++ b/docs/access-apis/sdk-prerequisites.md
@@ -7,7 +7,7 @@ title: Backend Use
 
 :::tip
 
-If you are planning to use Lava for frontend development, you simply need to visit our [Gateway](https://gateway.lavanet.xyz/) to get started!
+If you are planning to use Lava for frontend development, you simply need to visit our [Gateway](https://gateway.lavanet.xyz/?utm_source=lava-sdk-docs&utm_medium=docs&utm_campaign=sdk-alpha-launch) to get started!
  Read more about how badges make keyless frontend development safe [here](/badge-server).
 
 :::
@@ -19,7 +19,7 @@ The first step to using the Lava SDK is to register for the Lava Gateway. You wi
 
 <center>
 
-👉🏿[Register now](https://accounts.lavanet.xyz/register) if you haven’t already!
+👉🏿[Register now](https://accounts.lavanet.xyz/register?utm_source=lava-sdk-docs&utm_medium=docs&utm_campaign=sdk-alpha-launch) if you haven’t already!
 
 
 ![Gateway Register](/img/tutorial/sdk/GatewayRegister.png)


### PR DESCRIPTION
Per urgent request of Ethan,
modified links in `sdk-prerequisites.md` to use UTMs when linking to or referencing the Gateway.
This is to track traffic to Gateway during our SDK alpha launch.