### PR TITLE
Testnet 2 Hotfixes

### DIFF
--- a/docs/provider.md
+++ b/docs/provider.md
@@ -50,10 +50,10 @@ Lava's protocol expands its support to new RPCs by adding Specifications ("specs
 
 ### Querying Available APIs and Chains {#chains}
 
-To obtain a list of available APIs and chains, [query all chain specs](https://public-rpc.lavanet.xyz/rest/lavanet/lava/spec/show_all_chains) or use the following CLI commands for detailed list:
+To obtain a list of available APIs and chains, [query all chain specs](https://https://public-rpc-testnet2.lavanet.xyz/rest/lavanet/lava/spec/show_all_chains) or use the following CLI commands for detailed list:
 
 ```bash
-lavad q spec list-spec --node https://public-rpc.lavanet.xyz:443/rpc/
+lavad q spec list-spec --node https://public-rpc-testnet2.lavanet.xyz:443/rpc/
 ```
 
 ## Next step: Setup a Provider

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -40,7 +40,7 @@ When staking as a provider, there are four main parameters used in the transacti
 1. **Stake**: The amount of LAVA to stake for the service.
 2. **Geolocation**: The location of the provider's nodes.
 3. **ChainID**: The identifier of the target blockchain network, such as Cosmos Mainnet, Ethereum Ropsten, etc.
-4. **Endpoints**: A list of endpoints, each defining an address, geolocation and an API interface such as REST, JSON-RPC, etc.
+4. **Endpoints**: A list of endpoints, each defining an address and geolocation
 
 Providers need to stake separately for each supported spec. For example, if you support both Cosmos and Ethereum, you will need two separate stakes. Once your request is verified and included in the chain state, you'll be included in the Pairing List starting from the next Epoch and can begin servicing consumer requests through your nodes.
 

--- a/docs/provider/provider-setup.md
+++ b/docs/provider/provider-setup.md
@@ -50,7 +50,7 @@ lavad tx pairing stake-provider [chain-id] [amount] [endpoint endpoint ...] [geo
 
 - **`chain-id`** - The ID of the serviced chain (e.g., **`COS4`** or **`FTM250`**).
 - **`amount`** - Stake amount for the specific chain (e.g., **`2010ulava`**).
-- **`endpoint` (OPTIONAL) ** - Provider host listener, composed of `provider-host:provider-port,interface,geolocation`
+- **`endpoint` (OPTIONAL)** - Provider host listener, composed of `provider-host:provider-port,interface,geolocation`. More than one can be specified. If you specify only one, it will be applied to all APIs.
 - **`geolocation`** - Indicates the geographical location where the process is located (e.g., **`1`** for US or **`2`** for EU).
 
 #### Flags Details
@@ -64,6 +64,19 @@ lavad tx pairing stake-provider [chain-id] [amount] [endpoint endpoint ...] [geo
 - **`--node`** - A RPC node for Lava (e.g., **`https://public-rpc-testnet2.lavanet.xyz:443/rpc/`**).
 
 ### Stake Examples
+
+#### Lava Testnet in US
+
+```bash
+lavad tx pairing stake-provider LAV1 \
+  "50000000000ulava" \
+   "lava.your-site.com:443,1" 1 \
+   --from my_account \
+   --provider-moniker my-lava-provider \
+    --gas-adjustment "1.5" \
+    --gas "auto" \ 
+    --gas-prices "0.0001ulava"
+```
 
 #### Ethereum Mainnet in US
 Ethereum and other EVMs usually have only `jsonrpc` interface:
@@ -234,6 +247,11 @@ endpoints:
     node-urls: 
       - url: http://127.0.0.1:1317
 ```
+
+:::tip
+If you're using `nginx` or another proxy as is recommended in our [TLS setup guide](/provider-tls), you will need to add `disable-tls: true` to each endpoint specified. This allows `nginx` to handle TLS directly. 
+:::
+
 
 ## Step 5: Check Provider liveliness
 To ensure the provider is up and running correctly `lavad` provides a command to setup the necessary clients and verify all parameters are well defined.

--- a/docs/provider/provider-setup.md
+++ b/docs/provider/provider-setup.md
@@ -50,7 +50,7 @@ lavad tx pairing stake-provider [chain-id] [amount] [endpoint endpoint ...] [geo
 
 - **`chain-id`** - The ID of the serviced chain (e.g., **`COS4`** or **`FTM250`**).
 - **`amount`** - Stake amount for the specific chain (e.g., **`2010ulava`**).
-- **`endpoint` (OPTIONAL)** - Provider host listener, composed of `provider-host:provider-port,interface,geolocation`. More than one can be specified. If you specify only one, it will be applied to all APIs.
+- **`endpoint`** - Provider host listener, composed of `provider-host:provider-port,geolocation`.
 - **`geolocation`** - Indicates the geographical location where the process is located (e.g., **`1`** for US or **`2`** for EU).
 
 #### Flags Details
@@ -84,7 +84,7 @@ Ethereum and other EVMs usually have only `jsonrpc` interface:
 ```bash
 lavad tx pairing stake-provider "ETH1" \
     "50000000000ulava" \
-    "provider-host.com:1337,jsonrpc,1" 1 \
+    "provider-host.com:1337,1" 1 \
     --from "my_account_name" \
     --provider-moniker "your-moniker" \
     --keyring-backend "test" \
@@ -100,7 +100,7 @@ Cosmos's usually have `rest`, `tendermintrpc` & `grpc` interface, all mandatory:
 ```bash
 lavad tx pairing stake-provider "COS5T" \
     "50000000000ulava" \
-    "provider-host.com:1986,tendermintrpc,rest,grpc" 1 \
+    "provider-host.com:1986,1" 1 \
     --from "my_account_name" \
     --provider-moniker "your-moniker" \
     --keyring-backend "test" \

--- a/docs/provider/provider-tls.md
+++ b/docs/provider/provider-tls.md
@@ -162,9 +162,9 @@ server {
 </TabItem>
 </Tabs>
 
-:::tip
+:::caution
 
-The above examples use ports `2223` and `2224`, respectively. You can choose any port that works for your purposes. Be aware that some ports on your OS may be used for internal communication and should be avoided. 
+The above examples use ports `443` for external listening and `2223` / `2224` for internal comms, respectively. Using ports other than `443` for external listening means that some users will not be able to connect to your provider. This can result in less rewards and poorer quality of service. For internal listening, be aware that some ports on your OS may be used for internal communication and should be avoided. 
 
 :::
 

--- a/docs/validator/validator-rejoin.md
+++ b/docs/validator/validator-rejoin.md
@@ -67,6 +67,11 @@ mv cosmovisor-upgrades cosmovisor
 
 ### 🔼 Update node configuration files
 
+:::tip
+It's recommended to run the following command:
+`lavad config chain-id lava-testnet-2`
+:::
+
 Check the following variables are set as follows:
 
 <details> <summary> 🗎 config.toml</summary>
@@ -83,6 +88,7 @@ seeds="3a445bfdbe2d0c8ee82461633aa3af31bc2b4dc0@testnet2-seed-node.lavanet.xyz:2
 
 <details> <summary> 🗎 client.toml </summary> 
 broadcast-mode = "sync"
+chain-id = “lava-testnet-2”
 </details>
 
 <br />


### PR DESCRIPTION
This PR introduces hotfixes that update docs in accordance with feedback received from community members who are onboarding during `lava-testnet-2`

✅ Incorporates:
- [DCR-60](https://www.notion.so/lavanet/Public-RPC-URL-requires-update-a35c90ec327d4fe4bbfbc77a50082f19?pvs=4)
- [DCR-59](https://www.notion.so/lavanet/Fix-stake-provider-example-93b1541c441f42fc9e45666e6c360e73?pvs=4)
- [DCR-57](https://www.notion.so/lavanet/Add-warning-about-using-alt-ports-e4d3e5d52aad46d393e161c70dcfea16?pvs=4)
- [DCR-56](https://www.notion.so/lavanet/Update-COS3-example-from-Provider-setup-0a1126d56416473292c3a20e1e6be7dd?pvs=4)
-[DCR-55](https://www.notion.so/lavanet/Add-Chain-id-Command-to-Rejoin-Guide-0d20850617914769ac8de4e2324dda19?pvs=4)

⏳ An exhaustive list of commits in this PR is listed here:
- [update validator rejoin with chain-id](https://github.com/lavanet/docs/commit/eb2ddb0dc11ab1952b35008c2b2d9bb62b4528c4)
- [fix endpoint conf on provider staking; add example](https://github.com/lavanet/docs/commit/1dbf33c6657761ad5b47a3afd125a62fb1d16466)
- [add caution about 443 usage with provider](https://github.com/lavanet/docs/commit/db23ffe999de3111b65cb3edd838181c6abfcd0f)
- [correct public rpc url on provider page](https://github.com/lavanet/docs/commit/c65ba51eb138723c93070d24f1a6ad312af97fa1)
- [remove api-interface from endpoints](https://github.com/lavanet/docs/commit/efedb3cefda28a712e20943eeb059fe108990098)