### PR TITLE
Lava Phase II - Documentation Touchups

### DIFF
--- a/docs/access-apis/sdk-getting-started.md
+++ b/docs/access-apis/sdk-getting-started.md
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 
 ### 0. Sign up for an Account on the Gateway!
 
-While not a strict prerequisite for using the SDK - using the [Lava Gateway](https://gateway.lavanet.xyz/?utm_source=sdk-frontend-page&utm_medium=docs&utm_campaign=docs-to-gateway) gives an easy and free way to get a `privateKey` and/or `badge`, which LavaSDK requires to initialize. We recommend deciding whether you're going to use Lava on the [backend](/sdk-backend) or [frontend](/sdk-frontend) and starting there.
+While not a strict prerequisite for using the SDK - using the [Lava Gateway](https://gateway.lavanet.xyz/?utm_source=sdk-frontend-page&utm_medium=docs&utm_campaign=docs-to-gateway) gives an easy and free way to get a `privateKey` and/or `badge`, which LavaSDK requires to initialize. We recommend deciding whether you're going to use Lava on the [backend](/sdk-backend) or [frontend](/sdk-frontend) and starting there. LavaSDK is peer-to-peer (p2p) and executes relays in a  decentralized manner. 
 
 ### 1. Set up a new Node.JS project using Node Package Manager 
 To get started, we'll opt for a simple node application.

--- a/docs/chains/chains.mdx
+++ b/docs/chains/chains.mdx
@@ -14,6 +14,8 @@ import DocCardList from '@theme/DocCardList';
 ❓ Looking for a chain other than the ones listed here?
 Make a [**blockchain integration request**](https://lavanet.upvoty.com/b/blockchain-integration-request/)!
 
+🔗 You can get RPC endpoints for these chains on our [*Gateway*](https://gateway.lavanet.xyz/?utm_source=chains-page&utm_medium=docs&utm_campaign=docs-to-gateway) and we host [*Public Endpoints*](/public-rpc#incentivized-public-rpc-) for some chains here.
+
 :::caution Work in Progress
 
 Our `testnet` documentation is a work-in-progress. The following chains are LIVE (🔥) on Lava, but not yet documented: **Aptos**, **Arbitrum**, **Base**, **Canto**, **Fantom**, **Osmosis**, and **Polygon**.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -48,7 +48,7 @@ Lava documentation is intended to be the definitive reference for all technical 
 
 ## Quick Links 🔗
 
-- [🚪 Gateway](https://gateway.lavanet.xyz/login?utm_source=intro-page&utm_medium=docs&utm_campaign=docs-to-gateway) - Quick access APIs
+- [🚪 Gateway](https://gateway.lavanet.xyz/?utm_source=intro-page&utm_medium=docs&utm_campaign=docs-to-gateway) - Quick access APIs
 - [🔭 Explorer](https://lava.explorers.guru/) - Use our Official Block Explorer
 - [💬 Community Forum](https://community.lavanet.xyz/?utm_source=intro-page&utm_medium=docs) - Long-form Discussion
 - [🐦 Twitter/X Account](https://twitter.com/lavanetxyz) - Follow us on X!

--- a/docs/provider/provider-setup.md
+++ b/docs/provider/provider-setup.md
@@ -66,6 +66,7 @@ If no arguments are provided, the default configuration file is used. All config
 - **`--pprof-address`**: pprof server address, used for code profiling (default: **`""`**)
 - **`--cache`**: Address for a cache server to improve performance (default: **`""`**)
 - **`--parallel-connections`**: Number of parallel connections (default: **`chainproxy.NumberOfParallelConnections`**)
+- **`--reward-server-storage`**:  The path to store reward server data (default **`".storage/rewardserver"`**)
 
 ### Configuration Examples
 

--- a/docs/specs/add-spec.md
+++ b/docs/specs/add-spec.md
@@ -9,7 +9,9 @@ title: New Spec
 
 
 ## ℹ️ Context 
-Creating a new specification in the Lava ecosystem is important for those aiming to extend or introduce new functionalities within the network. In Lava, a specification, often referred to as a 'spec', acts as a foundational blueprint that details the APIs, required methods, compute unit costs, and expected behavior pertinent to a specific chain or application.
+Creating a new specification in the Lava ecosystem is important for those aiming to extend or introduce new functionalities within the network. Lava is modular; entirely new APIs, additional chains, and indexers can be supported without modifications to the Lava Protocol.  In Lava, a specification, often referred to as a 'spec', acts as a foundational blueprint that details the APIs, required methods, compute unit costs, and expected behavior pertinent to a specific chain or application. 
+
+Contributors play a vital role in Lava by adding new specs. Becoming a contributor to Lava is one of the most significant roles to play in the entire ecosystem. At Mainnet, it is planned for Contributors to be rewarded by the economics of the protocol. Creating new specs is not only a way to expand Lava, but has many other benefits: it builds a community of providers for an in-demand API, it allows modular changes to API collections on an as-needed basis, and it gives an opportunity to potentially earn rewards as a maintainer and creator of the spec. The contribution of new specs is highly appreciated and necessary endeavor for securing and improving web3 infrastructure.
 
 ## 🏗️ Essential Steps
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,7 +171,7 @@ const config = {
       announcementBar: {
         id: "no_token",
         content:
-          'Lava testnet is live. Mainnet tokens not yet available. <B>Beware of scams.</B> Need help? <a target="_blank" href="https://discord.gg/5VcqgwMmkA">Join our Discord.</a>',
+          'Lava Phase 2 is Live 🔥 Decentralized, Multi-chain RPC & APIs. <B>Mainnet Soon!</B>',
         backgroundColor: "#AA0000",
         textColor: "#FFFFFF",
         isCloseable: true,


### PR DESCRIPTION
This Pull Request (PR) implements minor requested changes to pull text in better alignment for Lava Phase II. Changes include updates to specs contributor section, fixing broken links, updated verbiage , and more links to Lava Gateway.

Incorporates:

- ✅ [DCR-87](https://www.notion.so/lavanet/Docs-Change-Requests-DCR-1b968fc9f7394122994546c05ccc0880?p=965c3f38dc564fffa4c7fedac8499bf5&pm=s) - Introduce role of Contributor in specs section
- ✅ [DCR-91](https://www.notion.so/lavanet/Docs-Change-Requests-DCR-1b968fc9f7394122994546c05ccc0880?p=270b64696c1046c59f52de4bfce277f8&pm=s) - Add link to Gateway on chain page 
- ✅ [DCR-92](https://www.notion.so/lavanet/Docs-Change-Requests-DCR-1b968fc9f7394122994546c05ccc0880?p=fff768f2a13140378a8ab2426b0fcd08&pm=s) - Add Reward Server Strorage Setup to Provider Setup
- ✅ [DCR-99](https://www.notion.so/lavanet/Docs-Change-Requests-DCR-1b968fc9f7394122994546c05ccc0880?p=a68cc71b05fb49dcad2b092da905546c&pm=s) - Correct the gateway link on the main page
- ✅ [DCR-100](https://www.notion.so/lavanet/Docs-Change-Requests-DCR-1b968fc9f7394122994546c05ccc0880?p=2adaf862b989475e99198ad4c24022b9&pm=s) - Change Banner at top of Docs for Lava Phase II
- ✅ [DCR-102](https://www.notion.so/lavanet/Docs-Change-Requests-DCR-1b968fc9f7394122994546c05ccc0880?p=f5e4aa55a57b4c718991a0461420a681&pm=s) - Clarify that LavaSDK is P2P