### PR TITLE
Restore NEAR iprpc Endpoints

### DIFF
--- a/docs/chains/near-chain/near-dev.md
+++ b/docs/chains/near-chain/near-dev.md
@@ -9,7 +9,20 @@ import TabItem from '@theme/TabItem';
 # Getting NEAR RPC
 
 ## NEAR ipRPC 🪙
-Lava🌋 will soon offer incentivized public RPC for NEAR. Developers can get free, public endpoints for all.
+
+Lava🌋 offers incentivized public RPC for NEAR. Developers can get free, public endpoints for all.
+
+### Mainnet 🌐
+
+| Service 🔌          | URL 🔗                                 |
+|---------------------|----------------------------------------|
+| 🟢  json-rpc  | <https://near.lava.build> |
+
+### Testnet 🧪
+
+| Service 🔌          | URL 🔗                                 |
+|---------------------|----------------------------------------|
+| 🟢  json-rpc  | <https://near-testnet.lava.build> |
 
 <hr />
 

--- a/docs/developer/endpoints/iprpc.md
+++ b/docs/developer/endpoints/iprpc.md
@@ -27,6 +27,21 @@ Lava works with various blockchains to establish **Incentivized Public RPC (ipRP
 
 <br/>
 
+## NEAR Endpoints 🌟
+
+### Mainnet 🌐 `NEAR`
+
+| Service 🔌          | URL 🔗                                 |
+|---------------------|----------------------------------------|
+| 🟢  json-rpc  | https://near.lava.build
+ |
+
+### Testnet 🧪 `NEART`
+
+| Service 🔌          | URL 🔗                                 |
+|---------------------|----------------------------------------|
+| 🟢  json-rpc  | https://near-testnet.lava.build |
+
 
 ## Evmos Endpoints 🌟
 


### PR DESCRIPTION
This PR is a quick-fix which adds back the NEAR Incentivized Public RPC endpoints to the docs.