### PR TITLE
Fix keyring documentation link

### DIFF
--- a/docs/intro/key-terms.md
+++ b/docs/intro/key-terms.md
@@ -138,7 +138,7 @@ title: 📝 Key Terms
 
 <details>
 <summary>Keyring</summary>
-The keyring holds the private/public keypairs used to interact with a node. For instance, a validator key needs to be set up before running the blockchain node, so that blocks can be correctly signed. The private key can be stored in different locations, called "backends", such as a file or the operating system's own key storage. <a href="https://docs.cosmos.network/main/run-node/keyring.html">(learn more here)</a>
+The keyring holds the private/public keypairs used to interact with a node. For instance, a validator key needs to be set up before running the blockchain node, so that blocks can be correctly signed. The private key can be stored in different locations, called "backends", such as a file or the operating system's own key storage. <a href="https://docs.cosmos.network/main/run-node/keyring">(learn more here)</a>
 </details>
 
 <details>


### PR DESCRIPTION
Current link points to https://docs.cosmos.network/main/run-node/keyring.html which 404s