### PR TITLE
Update gRPC port to 443 and URL

### DIFF
--- a/docs/developer/endpoints/public-rpc.md
+++ b/docs/developer/endpoints/public-rpc.md
@@ -11,7 +11,7 @@ title: Lava Public RPC 🌋
 |--------|-------|-------- |
 | 🟢 rpc | https://public-rpc-testnet2.lavanet.xyz:443    | HTTP/1.1 |
 | 🟢 rest | https://rest-public-rpc.lavanet.xyz:443    | HTTP/1.1 |
-| 🟢 grpc | public-rpc-testnet2.lavanet.xyz:443 |    HTTP/2 |
+| 🟢 grpc | grpc-public-rpc.lavanet.xyz:443 |    HTTP/2 |
 
 ## Incentivized Public RPC 💫
 

--- a/docs/developer/endpoints/public-rpc.md
+++ b/docs/developer/endpoints/public-rpc.md
@@ -11,7 +11,7 @@ title: Lava Public RPC 🌋
 |--------|-------|-------- |
 | 🟢 rpc | https://public-rpc-testnet2.lavanet.xyz:443    | HTTP/1.1 |
 | 🟢 rest | https://rest-public-rpc.lavanet.xyz:443    | HTTP/1.1 |
-| 🟢 grpc | public-rpc-testnet2.lavanet.xyz:9090 |    HTTP/2 |
+| 🟢 grpc | public-rpc-testnet2.lavanet.xyz:443 |    HTTP/2 |
 
 ## Incentivized Public RPC 💫
 

--- a/docs/lava-blockchain/badge-server.md
+++ b/docs/lava-blockchain/badge-server.md
@@ -103,7 +103,7 @@ Within this variable, lies a mapping structure, where each entry connects a geol
 This specifies the URL of the node with exposed gRPC port. Badge servers require access to a node with gRPC in order to function correctly.
 
 ```bash
-GRPC_URL=public-rpc-testnet2.lavanet.xyz:443
+GRPC_URL=grpc-public-rpc.lavanet.xyz:443
 ```
 <hr/>
 

--- a/docs/lava-blockchain/badge-server.md
+++ b/docs/lava-blockchain/badge-server.md
@@ -103,7 +103,7 @@ Within this variable, lies a mapping structure, where each entry connects a geol
 This specifies the URL of the node with exposed gRPC port. Badge servers require access to a node with gRPC in order to function correctly.
 
 ```bash
-GRPC_URL=public-rpc-testnet2.lavanet.xyz:9090
+GRPC_URL=public-rpc-testnet2.lavanet.xyz:443
 ```
 <hr/>
 


### PR DESCRIPTION
We are changing the gRPC port to 443 which is standard on SSL, as gRPC uses HTTP2 and TLS encrypted communications. Also this reduces the complexity as all other interfaces use 443.