### PR TITLE
Add mainnet sections for explorers, public RPC. Removed Agoric from iprpc page

### DIFF
--- a/docs/developer/endpoints/iprpc.md
+++ b/docs/developer/endpoints/iprpc.md
@@ -27,25 +27,9 @@ Lava works with various blockchains to establish **Incentivized Public RPC (ipRP
 
 <br/>
 
-## Agoric Endpoints 🌟
-
-### Mainnet 🌐 `AGR`
-
-| Service 🔌          | URL 🔗                                 |
-|---------------------|----------------------------------------|
-| 🟢  rest  | <https://agr.rest.lava.build> |
-| 🟢  grpc  | <https://agr.grpc.lava.build> |
-| 🟢  tendermintrpc | <https://agr.tendermint.lava.build> |
-
-### Testnet 🧪 `AGRT`
-
-| Service 🔌          | URL 🔗                                 |
-|---------------------|----------------------------------------|
-| 🟢  rest  | <https://agrt.rest.lava.build> |
-| 🟢  grpc  | <https://agrt.grpc.lava.build> |
-| 🟢  tendermintrpc | <https://agrt.tendermint.lava.build> |
-
-<br />
+:::info
+We will add Lava endpoints soon
+:::
 
 ## Axelar Endpoints 🌟
 

--- a/docs/developer/endpoints/public-rpc.md
+++ b/docs/developer/endpoints/public-rpc.md
@@ -3,9 +3,9 @@ slug: /public-rpc
 title: Lava Public RPC 🌋
 ---
 
-# Lava Public RPC (Testnet-2)
+# Lava Public RPC
 
-## Official Endpoints ⭕
+## Official Testnet-2 Endpoints ⭕
 
 | Service 🔌 | URL 🔗 | Protocol |
 |--------|-------|-------- |
@@ -14,6 +14,12 @@ title: Lava Public RPC 🌋
 | 🟢 rest | <https://lav1.lava.build:443>    | HTTP/1.1 |
 | 🟢 grpc | lav1.grpc.lava.build:443 |    HTTP/2 |
 | 🟢 archive/rpc | <https://lava-archive.lavanet.xyz:443> |    HTTP/1.1 |
+
+## Official Mainnet Endpoints 🌎
+
+:::info
+Official endpoint with Lava over Lava coming soon
+:::
 
 ## Incentivized Public RPC 💫
 

--- a/docs/intro/explorers.md
+++ b/docs/intro/explorers.md
@@ -18,6 +18,9 @@ https://lava.explorers.guru/
 </center>
 
 ## Community Block Explorers 🧑🏾‍🤝‍🧑🏾
+
+### TestNet Explorers
+
 - ✨[BCCNodes](https://explorer.bccnodes.com/lava-T/)
 - ✨[Kjnodes](https://explorer.kjnodes.com/lava-testnet)
 - ✨[Nodeist](https://exp.nodeist.net/Lava)
@@ -27,6 +30,10 @@ https://lava.explorers.guru/
 - ✨[Stake Village](https://exp.stakevillage.net/Lava-testnet)
 - ✨[STAKEME](https://lava.exploreme.pro)
 - ✨[AKNodes](https://explorer.aknodes.com/LAVA-TESTNET)
+
+### Mainnet Explorers
+
+Will be added soon
 
 
 ## Community Public RPC Explorer 🕵🏼


### PR DESCRIPTION
Add mainnet sections for explorers, public RPC. Removed Agoric from iprpc page

**remove Agoric**
![image](https://github.com/lavanet/docs/assets/133676565/6aafa678-f964-4f35-bcf9-818715acaa1e)

**added Mainnet section**
![image](https://github.com/lavanet/docs/assets/133676565/99390894-dab5-42c5-aa63-f96aeadbb3e4)

**Added Mainnet section**
![image](https://github.com/lavanet/docs/assets/133676565/6e8598cf-ff65-4182-b4e5-3dfc18c2e1d4)
