### PR TITLE
update: add KSYNC

### DIFF
--- a/docs/lava-blockchain/join-mainnet-manual-cosmovisor.md
+++ b/docs/lava-blockchain/join-mainnet-manual-cosmovisor.md
@@ -176,7 +176,7 @@ The following sections will describe how to install Cosmovisor for automating th
   sed -i -e "s|^seeds *=.*|seeds = \"$SEEDS\"|" $lava_home_folder/config/config.toml
   ```
 
-### State-Sync to latest Lava snapshot with KSYNC (_optional_) {#snapshots}
+### State-Sync to latest Lava snapshot with KSYNC (_recommended_) {#snapshots}
 
 You can state-sync to the latest available Lava state-sync snapshot archived by the [KYVE Network](https://kyve.network/) with the CLI tool [KSYNC](https://github.com/KYVENetwork/ksync).
 To start you have to install the latest Lava binary version, you can find the latest ones here: https://github.com/lavanet/lava/releases. You can install the latest Lava binary
@@ -213,16 +213,79 @@ ksync state-sync --binary /path/to/cosmovisor --chain-id kaon-1 -r
 This will take around one minute, after that you can continue to p2p sync from the snapshot height. You can find the archived state-sync snapshots [here](https://app.kaon.kyve.network/#/pools/30) detailed
 documentation regarding KSYNC [here](https://docs.kyve.network/access-data-sets/ksync/overview).
 
-### Enable and start the Cosmovisor service
+Finally, configure the Cosmovisor service to run on boot, and start it
 
-- Configure the Cosmovisor service to run on boot, and start it
-  ```bash
-  # Enable the cosmovisor service so that it will start automatically when the system boots
-  sudo systemctl daemon-reload
-  sudo systemctl enable cosmovisor.service
-  sudo systemctl restart systemd-journald
-  sudo systemctl start cosmovisor
-  ```
+```bash
+# Enable the cosmovisor service so that it will start automatically when the system boots
+sudo systemctl daemon-reload
+sudo systemctl enable cosmovisor.service
+sudo systemctl restart systemd-journald
+sudo systemctl start cosmovisor
+```
+
+### Block-Sync from genesis up to live height for full and archival node (_optional_) {#genesis-sync}
+
+You can skip this section if you have state-synced to live height already.
+
+If you want to perform a full sync from genesis up to live height in order to operate a full or even
+an archival Lava node you can block-sync all blocks which have been permanently archived by KYVE with KSYNC,
+very similar to the state-sync section above. To continue, make sure that KSYNC is installed, the installation
+steps are explained above and in the official KSYNC [documentation](https://docs.kyve.network/access-data-sets/ksync/overview).
+
+Next install all Lava upgrades in cosmovisor, the full version history can be found
+[here](https://github.com/cosmos/chain-registry/blob/master/lava/versions.json). If KSYNC should perform
+all the upgrades automatically you need to have a systemd process configured which automatically restarts
+KSYNC after an upgrade was executed, below you can find a template:
+
+```ksync.service
+[Unit]
+Description=KSYNC deamon supervising the ksync sync process
+After=network-online.target
+
+[Service]
+User=<user>
+WorkingDirectory=$HOME
+ExecStart=$HOME/ksync block-sync --binary="/path/to/cosmovisor" --chain-id="kaon-1" -y
+Restart=always
+RestartSec=10s
+LimitNOFILE=infinity
+Environment="DAEMON_NAME=<binary>"
+Environment="DAEMON_HOME=$HOME/.<binary>"
+Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
+Environment="DAEMON_RESTART_AFTER_UPGRADE=false"
+Environment="DAEMON_LOG_BUFFER_SIZE=512"
+Environment="UNSAFE_SKIP_BACKUP=true"
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Please replace the user and the path to your cosmovisor with your actual values.
+You can now reload the systemctl daemon:
+
+```bash
+sudo -S systemctl daemon-reload
+```
+
+and enable KSYNC as a service:
+
+```bash
+sudo -S systemctl enable ksync
+```
+
+You can now start KSYNC by executing:
+
+```bash
+sudo systemctl start ksync
+```
+
+Make sure to check that the service is running by executing:
+
+```bash
+sudo journalctl -u ksync -f
+```
+
+You can find another detailed example on how to sync from genesis with KSYNC [here](https://docs.kyve.network/access-data-sets/ksync/overview#example).
 
 ## 3. Verify
 

--- a/docs/lava-blockchain/join-mainnet-manual-cosmovisor.md
+++ b/docs/lava-blockchain/join-mainnet-manual-cosmovisor.md
@@ -3,49 +3,52 @@ sidebar_position: 2
 slug: /mainnet-manual-cosmovisor
 title: Option A - With Cosmovisor
 ---
-
 import RoadmapItem from '@site/src/components/RoadmapItem';
 import Admonition from '@theme/Admonition';
 
 # Join mainnet - Manual setup with Cosmovisor
-
 ## Prerequisites
 
 1. Verify [hardware requirements](reqs) are met
 2. Install package dependencies
-
-   - Note: You may need to run as `sudo`
-   - Required packages installation
-     ```bash
-     ### Packages installations
-     sudo apt update # in case of permissions error, try running with sudo
-     sudo apt install -y unzip logrotate git jq lz4 sed wget curl coreutils systemd
-     # Create the temp dir for the installation
-     temp_folder=$(mktemp -d) && cd $temp_folder
-     ```
-   - Go installation
-     ```bash
-     ### Configurations
-     go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
-     go_package_file_name=${go_package_url##*\/}
-     # Download GO
-     wget -q $go_package_url
-     # Unpack the GO installation file
-     sudo tar -C /usr/local -xzf $go_package_file_name
-     # Environment adjustments
-     echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
-     echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
-     source ~/.profile
-     ```
-   - Installation verifications
-
-     1. You can verify the installed go version by running: `go version`
-
-     2. The command `go env GOPATH` should include `$HOME/go`
+    - Note: You may need to run as `sudo`
+    - Required packages installation
+        
+        ```bash
+        ### Packages installations
+        sudo apt update # in case of permissions error, try running with sudo
+        sudo apt install -y unzip logrotate git jq lz4 sed wget curl coreutils systemd
+        # Create the temp dir for the installation
+        temp_folder=$(mktemp -d) && cd $temp_folder
+        ```
+        
+    - Go installation
+        
+        ```bash
+        ### Configurations
+        go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
+        go_package_file_name=${go_package_url##*\/}
+        # Download GO
+        wget -q $go_package_url
+        # Unpack the GO installation file
+        sudo tar -C /usr/local -xzf $go_package_file_name
+        # Environment adjustments
+        echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
+        echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
+        source ~/.profile
+        ```
+        
+    - Installation verifications
+        
+        
+        1. You can verify the installed go version by running: `go version`
+        
+        2. The command `go env GOPATH` should include `$HOME/go`
         If not, then, `export GOPATH=$HOME/go`
-
-     3. PATH should include `$HOME/go/bin`
+        
+        3. PATH should include `$HOME/go/bin`
         To verify PATH, run `echo $PATH`
+        
 
 ## 1. Set up the Lava node
 
@@ -54,127 +57,127 @@ The following sections will describe how to install Cosmovisor for automating th
 ### Set up Cosmovisor {#cosmovisor}
 
 - Set up cosmovisor to ensure any future upgrades happen flawlessly. To install Cosmovisor:
+    
+    ```bash
+    go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+    # Create the Cosmovisor folder and copy config files to it
+    export lava_home_folder="$HOME/.lava"
+    mkdir -p $lava_home_folder/cosmovisor/genesis/bin/
+    # Download the genesis binary
+    wget -O  $lava_home_folder/cosmovisor/genesis/bin/lavad "https://github.com/lavanet/lava/releases/download/v0.33.0/lavad-v0.33.0-linux-amd64"
+    chmod +x $lava_home_folder/cosmovisor/genesis/bin/lavad
+    ```
 
-  ```bash
-  go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
-  # Create the Cosmovisor folder and copy config files to it
-  export lava_home_folder="$HOME/.lava"
-  mkdir -p $lava_home_folder/cosmovisor/genesis/bin/
-  # Download the genesis binary
-  wget -O  $lava_home_folder/cosmovisor/genesis/bin/lavad "https://github.com/lavanet/lava/releases/download/v0.33.0/lavad-v0.33.0-linux-amd64"
-  chmod +x $lava_home_folder/cosmovisor/genesis/bin/lavad
-  ```
+    ```bash
+    # Set the environment variables
+    echo "# Setup Cosmovisor" >> ~/.profile
+    echo "export DAEMON_NAME=lavad" >> ~/.profile
+    echo "export CHAIN_ID=lava-mainnet-1" >> ~/.profile
+    echo "export DAEMON_HOME=$lava_home_folder" >> ~/.profile
+    echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=true" >> ~/.profile
+    echo "export DAEMON_LOG_BUFFER_SIZE=512" >> ~/.profile
+    echo "export DAEMON_RESTART_AFTER_UPGRADE=true" >> ~/.profile
+    echo "export UNSAFE_SKIP_BACKUP=true" >> ~/.profile
+    source ~/.profile
+    ```
 
-  ```bash
-  # Set the environment variables
-  echo "# Setup Cosmovisor" >> ~/.profile
-  echo "export DAEMON_NAME=lavad" >> ~/.profile
-  echo "export CHAIN_ID=lava-mainnet-1" >> ~/.profile
-  echo "export DAEMON_HOME=$lava_home_folder" >> ~/.profile
-  echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=true" >> ~/.profile
-  echo "export DAEMON_LOG_BUFFER_SIZE=512" >> ~/.profile
-  echo "export DAEMON_RESTART_AFTER_UPGRADE=true" >> ~/.profile
-  echo "export UNSAFE_SKIP_BACKUP=true" >> ~/.profile
-  source ~/.profile
-  ```
-
-  ```bash
-  # Initialize the chain
-  $lava_home_folder/cosmovisor/genesis/bin/lavad init \
-  my-node \
-  --chain-id lava-mainnet-1 \
-  --home $lava_home_folder
-  ```
+    ```bash
+    # Initialize the chain
+    $lava_home_folder/cosmovisor/genesis/bin/lavad init \
+    my-node \
+    --chain-id lava-mainnet-1 \
+    --home $lava_home_folder
+    ```
 
     <Admonition type="caution">
         Please note that cosmovisor will throw an error ⚠️ This is ok. The following error will be thrown,
         lstat /home/ubuntu/.lava/cosmovisor/current/upgrade-info.json: no such file or directory
     </Admonition>
 
-  ```bash
-  cosmovisor version
-  ```
-
-  Create the Cosmovisor systemd unit file
-
-  ```bash
-  echo "[Unit]
-      Description=Cosmovisor daemon
-      After=network-online.target
-      [Service]
-      Environment="DAEMON_NAME=lavad"
-      Environment="DAEMON_HOME=$lava_home_folder"
-      Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
-      Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=true"
-      Environment="DAEMON_LOG_BUFFER_SIZE=512"
-      Environment="UNSAFE_SKIP_BACKUP=true"
-      User=$USER
-      ExecStart=${HOME}/go/bin/cosmovisor start --home=$lava_home_folder
-      Restart=always
-      RestartSec=3
-      LimitNOFILE=infinity
-      LimitNPROC=infinity
-      [Install]
-      WantedBy=multi-user.target
-  " > cosmovisor.service
-
-  sudo mv cosmovisor.service /lib/systemd/system/cosmovisor.service
-  ```
+    ```bash
+    cosmovisor version
+    ```
+    
+    Create the Cosmovisor systemd unit file
+    
+    ```bash
+    echo "[Unit]
+        Description=Cosmovisor daemon
+        After=network-online.target
+        [Service]
+        Environment="DAEMON_NAME=lavad"
+        Environment="DAEMON_HOME=$lava_home_folder"
+        Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+        Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=true"
+        Environment="DAEMON_LOG_BUFFER_SIZE=512"
+        Environment="UNSAFE_SKIP_BACKUP=true"
+        User=$USER
+        ExecStart=${HOME}/go/bin/cosmovisor start --home=$lava_home_folder
+        Restart=always
+        RestartSec=3
+        LimitNOFILE=infinity
+        LimitNPROC=infinity
+        [Install]
+        WantedBy=multi-user.target
+    " > cosmovisor.service
+    
+    sudo mv cosmovisor.service /lib/systemd/system/cosmovisor.service
+    ```
 
 ### Download the genesis file
 
 - Set the genesis file in the configuration folder
 
-  ```bash
-  curl -Ls https://storage.googleapis.com/lavanet-public-asssets/tge/genesis.json > $lava_home_folder/config/genesis.json
-  ```
+    ```bash
+    curl -Ls https://storage.googleapis.com/lavanet-public-asssets/tge/genesis.json > $lava_home_folder/config/genesis.json
+    ```
 
 - Set up configuration files
 
-  ```bash
-  # Assuming lava is installed in it's default folder
-  # Determine OS
-  os_name=$(uname)
-  case "$(uname)" in
-  Darwin)
-      SED_INLINE="-i ''" ;;
-  Linux)
-      SED_INLINE="-i" ;;
-  *)
-      echo "unknown system: $(uname)"
-      exit 1 ;;
-  esac
+    ```bash
+    # Assuming lava is installed in it's default folder
+    # Determine OS
+    os_name=$(uname)
+    case "$(uname)" in
+    Darwin)
+        SED_INLINE="-i ''" ;;
+    Linux)
+        SED_INLINE="-i" ;;
+    *)
+        echo "unknown system: $(uname)"
+        exit 1 ;;
+    esac
 
-  # Edit config.toml file
-  sed $SED_INLINE \
-  -e 's|^timeout_propose =.*|timeout_propose = "10s"|' \
-  -e 's|^timeout_propose_delta =.*|timeout_propose_delta = "500ms"|' \
-  -e 's|^timeout_prevote =.*|timeout_prevote = "1s"|' \
-  -e 's|^timeout_prevote_delta =.*|timeout_prevote_delta = "500ms"|' \
-  -e 's|^timeout_precommit =.*|timeout_precommit = "500ms"|' \
-  -e 's|^timeout_precommit_delta =.*|timeout_precommit_delta = "1s"|' \
-  -e 's|^timeout_commit =.*|timeout_commit = "15s"|' \
-  -e 's|^create_empty_blocks =.*|create_empty_blocks = true|' \
-  -e 's|^create_empty_blocks_interval =.*|create_empty_blocks_interval = "15s"|' \
-  -e 's|^timeout_broadcast_tx_commit =.*|timeout_broadcast_tx_commit = "151s"|' \
-  -e 's|^skip_timeout_commit =.*|skip_timeout_commit = false|' \
-  $lava_home_folder/config/config.toml
+    # Edit config.toml file
+    sed $SED_INLINE \
+    -e 's|^timeout_propose =.*|timeout_propose = "10s"|' \
+    -e 's|^timeout_propose_delta =.*|timeout_propose_delta = "500ms"|' \
+    -e 's|^timeout_prevote =.*|timeout_prevote = "1s"|' \
+    -e 's|^timeout_prevote_delta =.*|timeout_prevote_delta = "500ms"|' \
+    -e 's|^timeout_precommit =.*|timeout_precommit = "500ms"|' \
+    -e 's|^timeout_precommit_delta =.*|timeout_precommit_delta = "1s"|' \
+    -e 's|^timeout_commit =.*|timeout_commit = "15s"|' \
+    -e 's|^create_empty_blocks =.*|create_empty_blocks = true|' \
+    -e 's|^create_empty_blocks_interval =.*|create_empty_blocks_interval = "15s"|' \
+    -e 's|^timeout_broadcast_tx_commit =.*|timeout_broadcast_tx_commit = "151s"|' \
+    -e 's|^skip_timeout_commit =.*|skip_timeout_commit = false|' \
+    $lava_home_folder/config/config.toml
 
-  # Edit app.toml file
-  sed $SED_INLINE \
-  -e 's|^pruning = .*|pruning = "nothing"|' \
-  -e "s|enable = .*|enable = true|" \
-  -e 's|^minimum-gas-prices = .*|minimum-gas-prices = "0.000000001ulava"|' \
-  $lava_home_folder/config/app.toml
-  ```
+    # Edit app.toml file
+    sed $SED_INLINE \
+    -e 's|^pruning = .*|pruning = "nothing"|' \
+    -e "s|enable = .*|enable = true|" \
+    -e 's|^minimum-gas-prices = .*|minimum-gas-prices = "0.000000001ulava"|' \
+    $lava_home_folder/config/app.toml
+    ```
 
 - Configure external seeds
 
-  ```bash
-  SEEDS="ebacd3e666003397fb685cd44956d33419219950@seed2.lava.chainlayer.net:26656,1105d3a3384edaa450f4f63c2b1ff08d366ee256@159.203.86.102:26656,f1caeaacfac32e4dd00916e8d912e1d834e94eb3@lava-seed.stakecito.com:26666,e4eb68c6fdfab1575b8794205caed47d4f737df4@lava-mainnet-seed.01node.com:26107,2d4db6b95804ea97e1f3655d043e6becf9bffc94@lava-seeds2.w3coins.io:11156,dcbfb490ea930fe9e8058089e3f6a14ca274c1c4@217.182.136.79:26656,e023c3892862744081360a99a2666e8111b196d3@38.242.213.53:26656,eafff29ec471bdd0985a9360b2c103997539c939@lava-seed.node.monster:26649,6a9a65d92b4820a5d198dd95743aa3059d0d3d4c@seed-lava.hashkey.cloud:26656"
+    ```bash
+    SEEDS="ebacd3e666003397fb685cd44956d33419219950@seed2.lava.chainlayer.net:26656,1105d3a3384edaa450f4f63c2b1ff08d366ee256@159.203.86.102:26656,f1caeaacfac32e4dd00916e8d912e1d834e94eb3@lava-seed.stakecito.com:26666,e4eb68c6fdfab1575b8794205caed47d4f737df4@lava-mainnet-seed.01node.com:26107,2d4db6b95804ea97e1f3655d043e6becf9bffc94@lava-seeds2.w3coins.io:11156,dcbfb490ea930fe9e8058089e3f6a14ca274c1c4@217.182.136.79:26656,e023c3892862744081360a99a2666e8111b196d3@38.242.213.53:26656,eafff29ec471bdd0985a9360b2c103997539c939@lava-seed.node.monster:26649,6a9a65d92b4820a5d198dd95743aa3059d0d3d4c@seed-lava.hashkey.cloud:26656"
 
-  sed -i -e "s|^seeds *=.*|seeds = \"$SEEDS\"|" $lava_home_folder/config/config.toml
-  ```
+    sed -i -e "s|^seeds *=.*|seeds = \"$SEEDS\"|" $lava_home_folder/config/config.toml
+    ```
 
 ### State-Sync to latest Lava snapshot with KSYNC (_recommended_) {#snapshots}
 
@@ -287,6 +290,18 @@ sudo journalctl -u ksync -f
 
 You can find another detailed example on how to sync from genesis with KSYNC [here](https://docs.kyve.network/access-data-sets/ksync/overview#example).
 
+### Enable and start the Cosmovisor service
+    
+- Configure the Cosmovisor service to run on boot, and start it
+    ```bash
+    # Enable the cosmovisor service so that it will start automatically when the system boots
+    sudo systemctl daemon-reload
+    sudo systemctl enable cosmovisor.service
+    sudo systemctl restart systemd-journald
+    sudo systemctl start cosmovisor
+    ```
+    
+
 ## 3. Verify
 
 ### Verify `cosmovisor` setup
@@ -294,14 +309,14 @@ You can find another detailed example on how to sync from genesis with KSYNC [he
 Make sure `cosmovisor` is running by checking the state of the cosmovisor service:
 
 - Check the status of the service
-  ```bash
-  sudo systemctl status cosmovisor
-  ```
+    ```bash
+    sudo systemctl status cosmovisor
+    ```
 - To view the service logs - to escape, hit CTRL+C
 
-  ```bash
-  sudo journalctl -u cosmovisor -f
-  ```
+    ```bash
+    sudo journalctl -u cosmovisor -f
+    ```
 
 ### Verify node status
 
@@ -315,7 +330,7 @@ $HOME/.lava/cosmovisor/current/bin/lavad status | jq .SyncInfo.catching_up
 ## Welcome to Lava Mainnet 🌋
 
 :::tip Joined Mainnet? Be a validator!
-You are now running a Node in the Lava network 🎉🥳!
+You are now running a Node in the Lava network 🎉🥳! 
 
 Congrats, happy to have you here 😻 Celebrate it with us on Discord.
 

--- a/docs/lava-blockchain/join-mainnet-manual-cosmovisor.md
+++ b/docs/lava-blockchain/join-mainnet-manual-cosmovisor.md
@@ -3,52 +3,49 @@ sidebar_position: 2
 slug: /mainnet-manual-cosmovisor
 title: Option A - With Cosmovisor
 ---
+
 import RoadmapItem from '@site/src/components/RoadmapItem';
 import Admonition from '@theme/Admonition';
 
 # Join mainnet - Manual setup with Cosmovisor
+
 ## Prerequisites
 
 1. Verify [hardware requirements](reqs) are met
 2. Install package dependencies
-    - Note: You may need to run as `sudo`
-    - Required packages installation
-        
-        ```bash
-        ### Packages installations
-        sudo apt update # in case of permissions error, try running with sudo
-        sudo apt install -y unzip logrotate git jq lz4 sed wget curl coreutils systemd
-        # Create the temp dir for the installation
-        temp_folder=$(mktemp -d) && cd $temp_folder
-        ```
-        
-    - Go installation
-        
-        ```bash
-        ### Configurations
-        go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
-        go_package_file_name=${go_package_url##*\/}
-        # Download GO
-        wget -q $go_package_url
-        # Unpack the GO installation file
-        sudo tar -C /usr/local -xzf $go_package_file_name
-        # Environment adjustments
-        echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
-        echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
-        source ~/.profile
-        ```
-        
-    - Installation verifications
-        
-        
-        1. You can verify the installed go version by running: `go version`
-        
-        2. The command `go env GOPATH` should include `$HOME/go`
+
+   - Note: You may need to run as `sudo`
+   - Required packages installation
+     ```bash
+     ### Packages installations
+     sudo apt update # in case of permissions error, try running with sudo
+     sudo apt install -y unzip logrotate git jq lz4 sed wget curl coreutils systemd
+     # Create the temp dir for the installation
+     temp_folder=$(mktemp -d) && cd $temp_folder
+     ```
+   - Go installation
+     ```bash
+     ### Configurations
+     go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
+     go_package_file_name=${go_package_url##*\/}
+     # Download GO
+     wget -q $go_package_url
+     # Unpack the GO installation file
+     sudo tar -C /usr/local -xzf $go_package_file_name
+     # Environment adjustments
+     echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
+     echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
+     source ~/.profile
+     ```
+   - Installation verifications
+
+     1. You can verify the installed go version by running: `go version`
+
+     2. The command `go env GOPATH` should include `$HOME/go`
         If not, then, `export GOPATH=$HOME/go`
-        
-        3. PATH should include `$HOME/go/bin`
+
+     3. PATH should include `$HOME/go/bin`
         To verify PATH, run `echo $PATH`
-        
 
 ## 1. Set up the Lava node
 
@@ -57,143 +54,175 @@ The following sections will describe how to install Cosmovisor for automating th
 ### Set up Cosmovisor {#cosmovisor}
 
 - Set up cosmovisor to ensure any future upgrades happen flawlessly. To install Cosmovisor:
-    
-    ```bash
-    go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
-    # Create the Cosmovisor folder and copy config files to it
-    export lava_home_folder="$HOME/.lava"
-    mkdir -p $lava_home_folder/cosmovisor/genesis/bin/
-    # Download the genesis binary
-    wget -O  $lava_home_folder/cosmovisor/genesis/bin/lavad "https://github.com/lavanet/lava/releases/download/v0.33.0/lavad-v0.33.0-linux-amd64"
-    chmod +x $lava_home_folder/cosmovisor/genesis/bin/lavad
-    ```
 
-    ```bash
-    # Set the environment variables
-    echo "# Setup Cosmovisor" >> ~/.profile
-    echo "export DAEMON_NAME=lavad" >> ~/.profile
-    echo "export CHAIN_ID=lava-mainnet-1" >> ~/.profile
-    echo "export DAEMON_HOME=$lava_home_folder" >> ~/.profile
-    echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=true" >> ~/.profile
-    echo "export DAEMON_LOG_BUFFER_SIZE=512" >> ~/.profile
-    echo "export DAEMON_RESTART_AFTER_UPGRADE=true" >> ~/.profile
-    echo "export UNSAFE_SKIP_BACKUP=true" >> ~/.profile
-    source ~/.profile
-    ```
+  ```bash
+  go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+  # Create the Cosmovisor folder and copy config files to it
+  export lava_home_folder="$HOME/.lava"
+  mkdir -p $lava_home_folder/cosmovisor/genesis/bin/
+  # Download the genesis binary
+  wget -O  $lava_home_folder/cosmovisor/genesis/bin/lavad "https://github.com/lavanet/lava/releases/download/v0.33.0/lavad-v0.33.0-linux-amd64"
+  chmod +x $lava_home_folder/cosmovisor/genesis/bin/lavad
+  ```
 
-    ```bash
-    # Initialize the chain
-    $lava_home_folder/cosmovisor/genesis/bin/lavad init \
-    my-node \
-    --chain-id lava-mainnet-1 \
-    --home $lava_home_folder
-    ```
+  ```bash
+  # Set the environment variables
+  echo "# Setup Cosmovisor" >> ~/.profile
+  echo "export DAEMON_NAME=lavad" >> ~/.profile
+  echo "export CHAIN_ID=lava-mainnet-1" >> ~/.profile
+  echo "export DAEMON_HOME=$lava_home_folder" >> ~/.profile
+  echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=true" >> ~/.profile
+  echo "export DAEMON_LOG_BUFFER_SIZE=512" >> ~/.profile
+  echo "export DAEMON_RESTART_AFTER_UPGRADE=true" >> ~/.profile
+  echo "export UNSAFE_SKIP_BACKUP=true" >> ~/.profile
+  source ~/.profile
+  ```
+
+  ```bash
+  # Initialize the chain
+  $lava_home_folder/cosmovisor/genesis/bin/lavad init \
+  my-node \
+  --chain-id lava-mainnet-1 \
+  --home $lava_home_folder
+  ```
 
     <Admonition type="caution">
         Please note that cosmovisor will throw an error ⚠️ This is ok. The following error will be thrown,
         lstat /home/ubuntu/.lava/cosmovisor/current/upgrade-info.json: no such file or directory
     </Admonition>
 
-    ```bash
-    cosmovisor version
-    ```
-    
-    Create the Cosmovisor systemd unit file
-    
-    ```bash
-    echo "[Unit]
-        Description=Cosmovisor daemon
-        After=network-online.target
-        [Service]
-        Environment="DAEMON_NAME=lavad"
-        Environment="DAEMON_HOME=$lava_home_folder"
-        Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
-        Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=true"
-        Environment="DAEMON_LOG_BUFFER_SIZE=512"
-        Environment="UNSAFE_SKIP_BACKUP=true"
-        User=$USER
-        ExecStart=${HOME}/go/bin/cosmovisor start --home=$lava_home_folder
-        Restart=always
-        RestartSec=3
-        LimitNOFILE=infinity
-        LimitNPROC=infinity
-        [Install]
-        WantedBy=multi-user.target
-    " > cosmovisor.service
-    
-    sudo mv cosmovisor.service /lib/systemd/system/cosmovisor.service
-    ```
+  ```bash
+  cosmovisor version
+  ```
+
+  Create the Cosmovisor systemd unit file
+
+  ```bash
+  echo "[Unit]
+      Description=Cosmovisor daemon
+      After=network-online.target
+      [Service]
+      Environment="DAEMON_NAME=lavad"
+      Environment="DAEMON_HOME=$lava_home_folder"
+      Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+      Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=true"
+      Environment="DAEMON_LOG_BUFFER_SIZE=512"
+      Environment="UNSAFE_SKIP_BACKUP=true"
+      User=$USER
+      ExecStart=${HOME}/go/bin/cosmovisor start --home=$lava_home_folder
+      Restart=always
+      RestartSec=3
+      LimitNOFILE=infinity
+      LimitNPROC=infinity
+      [Install]
+      WantedBy=multi-user.target
+  " > cosmovisor.service
+
+  sudo mv cosmovisor.service /lib/systemd/system/cosmovisor.service
+  ```
 
 ### Download the genesis file
 
 - Set the genesis file in the configuration folder
 
-    ```bash
-    curl -Ls https://storage.googleapis.com/lavanet-public-asssets/tge/genesis.json > $lava_home_folder/config/genesis.json
-    ```
+  ```bash
+  curl -Ls https://storage.googleapis.com/lavanet-public-asssets/tge/genesis.json > $lava_home_folder/config/genesis.json
+  ```
 
 - Set up configuration files
 
-    ```bash
-    # Assuming lava is installed in it's default folder
-    # Determine OS
-    os_name=$(uname)
-    case "$(uname)" in
-    Darwin)
-        SED_INLINE="-i ''" ;;
-    Linux)
-        SED_INLINE="-i" ;;
-    *)
-        echo "unknown system: $(uname)"
-        exit 1 ;;
-    esac
+  ```bash
+  # Assuming lava is installed in it's default folder
+  # Determine OS
+  os_name=$(uname)
+  case "$(uname)" in
+  Darwin)
+      SED_INLINE="-i ''" ;;
+  Linux)
+      SED_INLINE="-i" ;;
+  *)
+      echo "unknown system: $(uname)"
+      exit 1 ;;
+  esac
 
-    # Edit config.toml file
-    sed $SED_INLINE \
-    -e 's|^timeout_propose =.*|timeout_propose = "10s"|' \
-    -e 's|^timeout_propose_delta =.*|timeout_propose_delta = "500ms"|' \
-    -e 's|^timeout_prevote =.*|timeout_prevote = "1s"|' \
-    -e 's|^timeout_prevote_delta =.*|timeout_prevote_delta = "500ms"|' \
-    -e 's|^timeout_precommit =.*|timeout_precommit = "500ms"|' \
-    -e 's|^timeout_precommit_delta =.*|timeout_precommit_delta = "1s"|' \
-    -e 's|^timeout_commit =.*|timeout_commit = "15s"|' \
-    -e 's|^create_empty_blocks =.*|create_empty_blocks = true|' \
-    -e 's|^create_empty_blocks_interval =.*|create_empty_blocks_interval = "15s"|' \
-    -e 's|^timeout_broadcast_tx_commit =.*|timeout_broadcast_tx_commit = "151s"|' \
-    -e 's|^skip_timeout_commit =.*|skip_timeout_commit = false|' \
-    $lava_home_folder/config/config.toml
+  # Edit config.toml file
+  sed $SED_INLINE \
+  -e 's|^timeout_propose =.*|timeout_propose = "10s"|' \
+  -e 's|^timeout_propose_delta =.*|timeout_propose_delta = "500ms"|' \
+  -e 's|^timeout_prevote =.*|timeout_prevote = "1s"|' \
+  -e 's|^timeout_prevote_delta =.*|timeout_prevote_delta = "500ms"|' \
+  -e 's|^timeout_precommit =.*|timeout_precommit = "500ms"|' \
+  -e 's|^timeout_precommit_delta =.*|timeout_precommit_delta = "1s"|' \
+  -e 's|^timeout_commit =.*|timeout_commit = "15s"|' \
+  -e 's|^create_empty_blocks =.*|create_empty_blocks = true|' \
+  -e 's|^create_empty_blocks_interval =.*|create_empty_blocks_interval = "15s"|' \
+  -e 's|^timeout_broadcast_tx_commit =.*|timeout_broadcast_tx_commit = "151s"|' \
+  -e 's|^skip_timeout_commit =.*|skip_timeout_commit = false|' \
+  $lava_home_folder/config/config.toml
 
-    # Edit app.toml file
-    sed $SED_INLINE \
-    -e 's|^pruning = .*|pruning = "nothing"|' \
-    -e "s|enable = .*|enable = true|" \
-    -e 's|^minimum-gas-prices = .*|minimum-gas-prices = "0.000000001ulava"|' \
-    $lava_home_folder/config/app.toml
-    ```
+  # Edit app.toml file
+  sed $SED_INLINE \
+  -e 's|^pruning = .*|pruning = "nothing"|' \
+  -e "s|enable = .*|enable = true|" \
+  -e 's|^minimum-gas-prices = .*|minimum-gas-prices = "0.000000001ulava"|' \
+  $lava_home_folder/config/app.toml
+  ```
 
 - Configure external seeds
 
-    ```bash
-    SEEDS="ebacd3e666003397fb685cd44956d33419219950@seed2.lava.chainlayer.net:26656,1105d3a3384edaa450f4f63c2b1ff08d366ee256@159.203.86.102:26656,f1caeaacfac32e4dd00916e8d912e1d834e94eb3@lava-seed.stakecito.com:26666,e4eb68c6fdfab1575b8794205caed47d4f737df4@lava-mainnet-seed.01node.com:26107,2d4db6b95804ea97e1f3655d043e6becf9bffc94@lava-seeds2.w3coins.io:11156,dcbfb490ea930fe9e8058089e3f6a14ca274c1c4@217.182.136.79:26656,e023c3892862744081360a99a2666e8111b196d3@38.242.213.53:26656,eafff29ec471bdd0985a9360b2c103997539c939@lava-seed.node.monster:26649,6a9a65d92b4820a5d198dd95743aa3059d0d3d4c@seed-lava.hashkey.cloud:26656"
+  ```bash
+  SEEDS="ebacd3e666003397fb685cd44956d33419219950@seed2.lava.chainlayer.net:26656,1105d3a3384edaa450f4f63c2b1ff08d366ee256@159.203.86.102:26656,f1caeaacfac32e4dd00916e8d912e1d834e94eb3@lava-seed.stakecito.com:26666,e4eb68c6fdfab1575b8794205caed47d4f737df4@lava-mainnet-seed.01node.com:26107,2d4db6b95804ea97e1f3655d043e6becf9bffc94@lava-seeds2.w3coins.io:11156,dcbfb490ea930fe9e8058089e3f6a14ca274c1c4@217.182.136.79:26656,e023c3892862744081360a99a2666e8111b196d3@38.242.213.53:26656,eafff29ec471bdd0985a9360b2c103997539c939@lava-seed.node.monster:26649,6a9a65d92b4820a5d198dd95743aa3059d0d3d4c@seed-lava.hashkey.cloud:26656"
 
-    sed -i -e "s|^seeds *=.*|seeds = \"$SEEDS\"|" $lava_home_folder/config/config.toml
-    ```
+  sed -i -e "s|^seeds *=.*|seeds = \"$SEEDS\"|" $lava_home_folder/config/config.toml
+  ```
 
-### Download the latest Lava data snapshot (_optional_) {#snapshots}
+### State-Sync to latest Lava snapshot with KSYNC (_optional_) {#snapshots}
 
-_Coming soon_
+You can state-sync to the latest available Lava state-sync snapshot archived by the [KYVE Network](https://kyve.network/) with the CLI tool [KSYNC](https://github.com/KYVENetwork/ksync).
+To start you have to install the latest Lava binary version, you can find the latest ones here: https://github.com/lavanet/lava/releases. You can install the latest Lava binary
+already in the correct Cosmosvisor upgrade directory and update the symlink `current` to the latest version. Verify it by running: `./cosmovisor run version`.
+
+Next install KSYNC, if go1.22 is installed you can directly install it with:
+
+```bash
+go install github.com/KYVENetwork/ksync/cmd/ksync@latest
+```
+
+You can also build it from source:
+
+```bash
+git clone git@github.com:KYVENetwork/ksync.git
+cd ksync
+git checkout tags/vx.x.x -b vx.x.x
+make build
+cp build/ksync ~/go/bin/ksync
+```
+
+After KSYNC has been successfully installed and verified with `ksync version` you can state-sync to the latest available state-sync snapshot with the following command:
+
+```bash
+ksync state-sync --binary /path/to/lavad --chain-id kaon-1 -r
+```
+
+If you have installed the latest lava binary in cosmovisor you can also point the binary to cosmovisor:
+
+```bash
+ksync state-sync --binary /path/to/cosmovisor --chain-id kaon-1 -r
+```
+
+This will take around one minute, after that you can continue to p2p sync from the snapshot height. You can find the archived state-sync snapshots [here](https://app.kaon.kyve.network/#/pools/30) detailed
+documentation regarding KSYNC [here](https://docs.kyve.network/access-data-sets/ksync/overview).
 
 ### Enable and start the Cosmovisor service
-    
+
 - Configure the Cosmovisor service to run on boot, and start it
-    ```bash
-    # Enable the cosmovisor service so that it will start automatically when the system boots
-    sudo systemctl daemon-reload
-    sudo systemctl enable cosmovisor.service
-    sudo systemctl restart systemd-journald
-    sudo systemctl start cosmovisor
-    ```
-    
+  ```bash
+  # Enable the cosmovisor service so that it will start automatically when the system boots
+  sudo systemctl daemon-reload
+  sudo systemctl enable cosmovisor.service
+  sudo systemctl restart systemd-journald
+  sudo systemctl start cosmovisor
+  ```
 
 ## 3. Verify
 
@@ -202,14 +231,14 @@ _Coming soon_
 Make sure `cosmovisor` is running by checking the state of the cosmovisor service:
 
 - Check the status of the service
-    ```bash
-    sudo systemctl status cosmovisor
-    ```
+  ```bash
+  sudo systemctl status cosmovisor
+  ```
 - To view the service logs - to escape, hit CTRL+C
 
-    ```bash
-    sudo journalctl -u cosmovisor -f
-    ```
+  ```bash
+  sudo journalctl -u cosmovisor -f
+  ```
 
 ### Verify node status
 
@@ -223,7 +252,7 @@ $HOME/.lava/cosmovisor/current/bin/lavad status | jq .SyncInfo.catching_up
 ## Welcome to Lava Mainnet 🌋
 
 :::tip Joined Mainnet? Be a validator!
-You are now running a Node in the Lava network 🎉🥳! 
+You are now running a Node in the Lava network 🎉🥳!
 
 Congrats, happy to have you here 😻 Celebrate it with us on Discord.
 

--- a/docs/lava-blockchain/join-mainnet-manual.md
+++ b/docs/lava-blockchain/join-mainnet-manual.md
@@ -3,10 +3,10 @@ sidebar_position: 2
 slug: /mainnet-manual
 title: Option B - Without Cosmovisor
 ---
+
 import RoadmapItem from '@site/src/components/RoadmapItem';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
 
 # Join mainnet - Manual setup
 
@@ -18,155 +18,144 @@ Note that it does **not** include the "Cosmovisor" tool, hence once you install 
 
 1. Verify [hardware requirements](reqs) are met
 2. Install package dependencies
-    - Note: You may need to run as `sudo`
-    - Required packages installation
-        
-        ```bash
-        ### Packages installations
-        sudo apt update # In case of permissions error, try running with sudo
-        sudo apt install -y unzip logrotate git jq sed wget curl coreutils systemd
-        # Create the temp dir for the installation
-        temp_folder=$(mktemp -d) && cd $temp_folder
-        ```
-        
-    - Go installation
-        
-        ```bash
-        ### Configurations
-        go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
-        go_package_file_name=${go_package_url##*\/}
-        # Download GO
-        wget -q $go_package_url
-        # Unpack the GO installation file
-        sudo tar -C /usr/local -xzf $go_package_file_name
-        # Environment adjustments
-        echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
-        echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
-        source ~/.profile
-        ```
-        
-    - Installation verifications
-        
-        
-        1. You can verify the installed go version by running: `go version`
-        
-        2. The command `go env GOPATH` should include `$HOME/go`
+
+   - Note: You may need to run as `sudo`
+   - Required packages installation
+     ```bash
+     ### Packages installations
+     sudo apt update # In case of permissions error, try running with sudo
+     sudo apt install -y unzip logrotate git jq sed wget curl coreutils systemd
+     # Create the temp dir for the installation
+     temp_folder=$(mktemp -d) && cd $temp_folder
+     ```
+   - Go installation
+     ```bash
+     ### Configurations
+     go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
+     go_package_file_name=${go_package_url##*\/}
+     # Download GO
+     wget -q $go_package_url
+     # Unpack the GO installation file
+     sudo tar -C /usr/local -xzf $go_package_file_name
+     # Environment adjustments
+     echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
+     echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
+     source ~/.profile
+     ```
+   - Installation verifications
+
+     1. You can verify the installed go version by running: `go version`
+
+     2. The command `go env GOPATH` should include `$HOME/go`
         If not, then, `export GOPATH=$HOME/go`
-        
-        3. PATH should include `$HOME/go/bin`
+
+     3. PATH should include `$HOME/go/bin`
         To verify PATH, run `echo $PATH`
-        
 
 ## 1. Set up a local node
 
 ### Download app configurations
 
 - Download setup configuration
-    
-    Download the configuration files needed for the installation
-    
-    ```bash
-    # Download the installation setup configuration
-    git clone https://github.com/lavanet/lava-config.git
-    cd lava-config/mainnet
-    # Read the configuration from the file
-    # Note: you can take a look at the config file and verify configurations
-    source setup_config/setup_config.sh
-    ```
-    
+  Download the configuration files needed for the installation
+  ```bash
+  # Download the installation setup configuration
+  git clone https://github.com/lavanet/lava-config.git
+  cd lava-config/mainnet
+  # Read the configuration from the file
+  # Note: you can take a look at the config file and verify configurations
+  source setup_config/setup_config.sh
+  ```
 - Set app configurations
-        
-    Copy lavad default config files to config Lava config folder
-    
-    ```bash
-    echo "Lava config file path: $lava_config_folder"
-    mkdir -p $lavad_home_folder
-    mkdir -p $lava_config_folder
-    cp default_lavad_config_files/* $lava_config_folder
-    ```
-    
+  Copy lavad default config files to config Lava config folder
+  ```bash
+  echo "Lava config file path: $lava_config_folder"
+  mkdir -p $lavad_home_folder
+  mkdir -p $lava_config_folder
+  cp default_lavad_config_files/* $lava_config_folder
+  ```
 
 ### Set the genesis file
 
 - Set the genesis JSON file in the configuration folder
-    
-    ```bash
-    # Copy the genesis.json file to the Lava config folder
-    cp genesis_json/genesis.json $lava_config_folder/genesis.json
-    ```
+  ```bash
+  # Copy the genesis.json file to the Lava config folder
+  cp genesis_json/genesis.json $lava_config_folder/genesis.json
+  ```
 
 ## 2. Join the Lava Mainnet
 
 ### Copy the genesis binary
 
-- Set the lavad binary location and copy the genesis binary to it
+- Set the lavad binary location and copy the genesis binary to it (note that v2.2.0 is not the latest version anymore and the
+  latest available ones can be found [here](https://github.com/lavanet/lava/releases))
 
-    ```bash
-    # Set and create the lavad binary path
-    lavad_binary_path="$HOME/go/bin/"
-    mkdir -p $lavad_binary_path
-    # Download the genesis binary to the lava path
-    wget -O ./lavad "https://github.com/lavanet/lava/releases/download/v2.2.0/lavad-v2.2.0-linux-amd64"
-    chmod +x lavad
-    # Lavad should now be accessible from PATH, to verify, try running
-    cp lavad /usr/local/bin
-    # In case it is not accessible, make sure $lavad_binary_path is part of PATH (you can refer to the "Go installation" section)
-    lavad --help # Make sure you can see the lavad binary help printed out
-    ```
+  ```bash
+  # Set and create the lavad binary path
+  lavad_binary_path="$HOME/go/bin/"
+  mkdir -p $lavad_binary_path
+  # Download the genesis binary to the lava path
+  wget -O ./lavad "https://github.com/lavanet/lava/releases/download/v2.2.0/lavad-v2.2.0-linux-amd64"
+  chmod +x lavad
+  # Lavad should now be accessible from PATH, to verify, try running
+  cp lavad /usr/local/bin
+  # In case it is not accessible, make sure $lavad_binary_path is part of PATH (you can refer to the "Go installation" section)
+  lavad --help # Make sure you can see the lavad binary help printed out
+  ```
 
 ### Start running the node using the genesis binary
 
 - Create a systemd service to run the Lava node
 
-    ```bash
-    # Create systemd unit file with logrotate
-    echo "[Unit]
-    Description=Lava Node
-    After=network-online.target
-    [Service]
-    User=$USER
-    ExecStart=$(which lavad) start --home=$lavad_home_folder --p2p.seeds $seed_node
-    Restart=always
-    RestartSec=180
-    LimitNOFILE=infinity
-    LimitNPROC=infinity
-    [Install]
-    WantedBy=multi-user.target" >lavad.service
-    sudo mv lavad.service /lib/systemd/system/lavad.service
-    ```
+  ```bash
+  # Create systemd unit file with logrotate
+  echo "[Unit]
+  Description=Lava Node
+  After=network-online.target
+  [Service]
+  User=$USER
+  ExecStart=$(which lavad) start --home=$lavad_home_folder --p2p.seeds $seed_node
+  Restart=always
+  RestartSec=180
+  LimitNOFILE=infinity
+  LimitNPROC=infinity
+  [Install]
+  WantedBy=multi-user.target" >lavad.service
+  sudo mv lavad.service /lib/systemd/system/lavad.service
+  ```
 
-### Download the latest Lava data snapshot (_optional_) {#snapshots} 
+### State-Sync to latest Lava snapshot with KSYNC (_recommended_) {#snapshots}
 
-_Coming soon_
+Find the steps [here](/mainnet-manual-cosmovisor#snapshots) in order to state-sync to the latest available snapshot.
 
 ### Service start and validation
 
 - Configure the lavad service to run on boot, and start it
 
-    ```bash
-    # Enable the lavad service so that it will start automatically when the system boots
-    sudo systemctl daemon-reload
-    sudo systemctl enable lavad.service
-    sudo systemctl restart systemd-journald
-    sudo systemctl start lavad
-    ```
+  ```bash
+  # Enable the lavad service so that it will start automatically when the system boots
+  sudo systemctl daemon-reload
+  sudo systemctl enable lavad.service
+  sudo systemctl restart systemd-journald
+  sudo systemctl start lavad
+  ```
 
 - Check the state of the lavad service
-    
-    ```bash
-    sudo systemctl status lavad
-    # To view the service logs
-    sudo journalctl -u lavad -f
-    ```
+
+  ```bash
+  sudo systemctl status lavad
+  # To view the service logs
+  sudo journalctl -u lavad -f
+  ```
 
 - Check the latest block
-   
-    ```bash
-    curl -X GET -H "Content-Type: application/json" \
-    https://lava.rest.lava.build/cosmos/base/tendermint/v1beta1/blocks/latest
-    ```
+  ```bash
+  curl -X GET -H "Content-Type: application/json" \
+  https://lava.rest.lava.build/cosmos/base/tendermint/v1beta1/blocks/latest
+  ```
 
 ## 3. Upgrades {#upgrades}
+
 Lava blockchain upgrades requires you to update `lavad`. This guide covers the manual steps for doing so, assuming you do not use Cosmovisor.
 
 ### How to know there's an upgrade?
@@ -189,8 +178,8 @@ This situation requires a different binary (`lavad`) to work with, the process i
 
 ### Upgrades list history
 
-Below, you can find tracking of the required upgrade for block height. 
-Versions are tracked in [Lava git](https://github.com/lavanet/lava) (build from source or use the release page). 
+Below, you can find tracking of the required upgrade for block height.
+Versions are tracked in [Lava git](https://github.com/lavanet/lava) (build from source or use the release page).
 
 ### lava-mainnet-1
 
@@ -200,6 +189,8 @@ Versions are tracked in [Lava git](https://github.com/lavanet/lava) (build from 
 | v0.35.0      | 413000       |
 | v1.0.1       | 451000       |
 | v2.2.0       | 888500       |
+| v3.1.0       | 1308000      |
+| v4.1.0       | 1663000      |
 
 ### Steps for upgrading your node
 
@@ -211,7 +202,6 @@ temp_folder=$(mktemp -d) && cd $temp_folder
 required_upgrade_name="v2.2.0" # CHANGE THIS
 upgrade_binary_url="https://github.com/lavanet/lava/releases/download/$required_upgrade_name/lavad-$required_upgrade_name-linux-amd64"
 ```
-
 
 2. Kill all current lavad processes
 
@@ -251,7 +241,7 @@ sudo journalctl -u lavad -f
 ## Welcome to Lava Mainnet 🌋
 
 :::tip Joined Mainnet? Be a validator!
-You are now running a Node in the Lava network 🎉🥳! 
+You are now running a Node in the Lava network 🎉🥳!
 
 Congrats, happy to have you here 😻 Celebrate it with us on Discord.
 

--- a/docs/lava-blockchain/join-mainnet-manual.md
+++ b/docs/lava-blockchain/join-mainnet-manual.md
@@ -3,10 +3,10 @@ sidebar_position: 2
 slug: /mainnet-manual
 title: Option B - Without Cosmovisor
 ---
-
 import RoadmapItem from '@site/src/components/RoadmapItem';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
 
 # Join mainnet - Manual setup
 
@@ -18,111 +18,122 @@ Note that it does **not** include the "Cosmovisor" tool, hence once you install 
 
 1. Verify [hardware requirements](reqs) are met
 2. Install package dependencies
-
-   - Note: You may need to run as `sudo`
-   - Required packages installation
-     ```bash
-     ### Packages installations
-     sudo apt update # In case of permissions error, try running with sudo
-     sudo apt install -y unzip logrotate git jq sed wget curl coreutils systemd
-     # Create the temp dir for the installation
-     temp_folder=$(mktemp -d) && cd $temp_folder
-     ```
-   - Go installation
-     ```bash
-     ### Configurations
-     go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
-     go_package_file_name=${go_package_url##*\/}
-     # Download GO
-     wget -q $go_package_url
-     # Unpack the GO installation file
-     sudo tar -C /usr/local -xzf $go_package_file_name
-     # Environment adjustments
-     echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
-     echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
-     source ~/.profile
-     ```
-   - Installation verifications
-
-     1. You can verify the installed go version by running: `go version`
-
-     2. The command `go env GOPATH` should include `$HOME/go`
+    - Note: You may need to run as `sudo`
+    - Required packages installation
+        
+        ```bash
+        ### Packages installations
+        sudo apt update # In case of permissions error, try running with sudo
+        sudo apt install -y unzip logrotate git jq sed wget curl coreutils systemd
+        # Create the temp dir for the installation
+        temp_folder=$(mktemp -d) && cd $temp_folder
+        ```
+        
+    - Go installation
+        
+        ```bash
+        ### Configurations
+        go_package_url="https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
+        go_package_file_name=${go_package_url##*\/}
+        # Download GO
+        wget -q $go_package_url
+        # Unpack the GO installation file
+        sudo tar -C /usr/local -xzf $go_package_file_name
+        # Environment adjustments
+        echo "export PATH=\$PATH:/usr/local/go/bin" >>~/.profile
+        echo "export PATH=\$PATH:\$(go env GOPATH)/bin" >>~/.profile
+        source ~/.profile
+        ```
+        
+    - Installation verifications
+        
+        
+        1. You can verify the installed go version by running: `go version`
+        
+        2. The command `go env GOPATH` should include `$HOME/go`
         If not, then, `export GOPATH=$HOME/go`
-
-     3. PATH should include `$HOME/go/bin`
+        
+        3. PATH should include `$HOME/go/bin`
         To verify PATH, run `echo $PATH`
+        
 
 ## 1. Set up a local node
 
 ### Download app configurations
 
 - Download setup configuration
-  Download the configuration files needed for the installation
-  ```bash
-  # Download the installation setup configuration
-  git clone https://github.com/lavanet/lava-config.git
-  cd lava-config/mainnet
-  # Read the configuration from the file
-  # Note: you can take a look at the config file and verify configurations
-  source setup_config/setup_config.sh
-  ```
+    
+    Download the configuration files needed for the installation
+    
+    ```bash
+    # Download the installation setup configuration
+    git clone https://github.com/lavanet/lava-config.git
+    cd lava-config/mainnet
+    # Read the configuration from the file
+    # Note: you can take a look at the config file and verify configurations
+    source setup_config/setup_config.sh
+    ```
+    
 - Set app configurations
-  Copy lavad default config files to config Lava config folder
-  ```bash
-  echo "Lava config file path: $lava_config_folder"
-  mkdir -p $lavad_home_folder
-  mkdir -p $lava_config_folder
-  cp default_lavad_config_files/* $lava_config_folder
-  ```
+        
+    Copy lavad default config files to config Lava config folder
+    
+    ```bash
+    echo "Lava config file path: $lava_config_folder"
+    mkdir -p $lavad_home_folder
+    mkdir -p $lava_config_folder
+    cp default_lavad_config_files/* $lava_config_folder
+    ```
+    
 
 ### Set the genesis file
 
 - Set the genesis JSON file in the configuration folder
-  ```bash
-  # Copy the genesis.json file to the Lava config folder
-  cp genesis_json/genesis.json $lava_config_folder/genesis.json
-  ```
+    
+    ```bash
+    # Copy the genesis.json file to the Lava config folder
+    cp genesis_json/genesis.json $lava_config_folder/genesis.json
+    ```
 
 ## 2. Join the Lava Mainnet
 
 ### Copy the genesis binary
 
-- Set the lavad binary location and copy the genesis binary to it (note that v2.2.0 is not the latest version anymore and the
-  latest available ones can be found [here](https://github.com/lavanet/lava/releases))
+- Set the lavad binary location and copy the genesis binary to it
 
-  ```bash
-  # Set and create the lavad binary path
-  lavad_binary_path="$HOME/go/bin/"
-  mkdir -p $lavad_binary_path
-  # Download the genesis binary to the lava path
-  wget -O ./lavad "https://github.com/lavanet/lava/releases/download/v2.2.0/lavad-v2.2.0-linux-amd64"
-  chmod +x lavad
-  # Lavad should now be accessible from PATH, to verify, try running
-  cp lavad /usr/local/bin
-  # In case it is not accessible, make sure $lavad_binary_path is part of PATH (you can refer to the "Go installation" section)
-  lavad --help # Make sure you can see the lavad binary help printed out
-  ```
+    ```bash
+    # Set and create the lavad binary path
+    lavad_binary_path="$HOME/go/bin/"
+    mkdir -p $lavad_binary_path
+    # Download the genesis binary to the lava path
+    wget -O ./lavad "https://github.com/lavanet/lava/releases/download/v2.2.0/lavad-v2.2.0-linux-amd64"
+    chmod +x lavad
+    # Lavad should now be accessible from PATH, to verify, try running
+    cp lavad /usr/local/bin
+    # In case it is not accessible, make sure $lavad_binary_path is part of PATH (you can refer to the "Go installation" section)
+    lavad --help # Make sure you can see the lavad binary help printed out
+    ```
 
 ### Start running the node using the genesis binary
 
 - Create a systemd service to run the Lava node
 
-  ```bash
-  # Create systemd unit file with logrotate
-  echo "[Unit]
-  Description=Lava Node
-  After=network-online.target
-  [Service]
-  User=$USER
-  ExecStart=$(which lavad) start --home=$lavad_home_folder --p2p.seeds $seed_node
-  Restart=always
-  RestartSec=180
-  LimitNOFILE=infinity
-  LimitNPROC=infinity
-  [Install]
-  WantedBy=multi-user.target" >lavad.service
-  sudo mv lavad.service /lib/systemd/system/lavad.service
-  ```
+    ```bash
+    # Create systemd unit file with logrotate
+    echo "[Unit]
+    Description=Lava Node
+    After=network-online.target
+    [Service]
+    User=$USER
+    ExecStart=$(which lavad) start --home=$lavad_home_folder --p2p.seeds $seed_node
+    Restart=always
+    RestartSec=180
+    LimitNOFILE=infinity
+    LimitNPROC=infinity
+    [Install]
+    WantedBy=multi-user.target" >lavad.service
+    sudo mv lavad.service /lib/systemd/system/lavad.service
+    ```
 
 ### State-Sync to latest Lava snapshot with KSYNC (_recommended_) {#snapshots}
 
@@ -132,30 +143,30 @@ Find the steps [here](/mainnet-manual-cosmovisor#snapshots) in order to state-sy
 
 - Configure the lavad service to run on boot, and start it
 
-  ```bash
-  # Enable the lavad service so that it will start automatically when the system boots
-  sudo systemctl daemon-reload
-  sudo systemctl enable lavad.service
-  sudo systemctl restart systemd-journald
-  sudo systemctl start lavad
-  ```
+    ```bash
+    # Enable the lavad service so that it will start automatically when the system boots
+    sudo systemctl daemon-reload
+    sudo systemctl enable lavad.service
+    sudo systemctl restart systemd-journald
+    sudo systemctl start lavad
+    ```
 
 - Check the state of the lavad service
-
-  ```bash
-  sudo systemctl status lavad
-  # To view the service logs
-  sudo journalctl -u lavad -f
-  ```
+    
+    ```bash
+    sudo systemctl status lavad
+    # To view the service logs
+    sudo journalctl -u lavad -f
+    ```
 
 - Check the latest block
-  ```bash
-  curl -X GET -H "Content-Type: application/json" \
-  https://lava.rest.lava.build/cosmos/base/tendermint/v1beta1/blocks/latest
-  ```
+   
+    ```bash
+    curl -X GET -H "Content-Type: application/json" \
+    https://lava.rest.lava.build/cosmos/base/tendermint/v1beta1/blocks/latest
+    ```
 
 ## 3. Upgrades {#upgrades}
-
 Lava blockchain upgrades requires you to update `lavad`. This guide covers the manual steps for doing so, assuming you do not use Cosmovisor.
 
 ### How to know there's an upgrade?
@@ -178,8 +189,8 @@ This situation requires a different binary (`lavad`) to work with, the process i
 
 ### Upgrades list history
 
-Below, you can find tracking of the required upgrade for block height.
-Versions are tracked in [Lava git](https://github.com/lavanet/lava) (build from source or use the release page).
+Below, you can find tracking of the required upgrade for block height. 
+Versions are tracked in [Lava git](https://github.com/lavanet/lava) (build from source or use the release page). 
 
 ### lava-mainnet-1
 
@@ -189,7 +200,7 @@ Versions are tracked in [Lava git](https://github.com/lavanet/lava) (build from 
 | v0.35.0      | 413000       |
 | v1.0.1       | 451000       |
 | v2.2.0       | 888500       |
-| v3.1.0       | 1308000      |
+| v3.1.0       | 1308000	    |
 | v4.1.0       | 1663000      |
 
 ### Steps for upgrading your node
@@ -202,6 +213,7 @@ temp_folder=$(mktemp -d) && cd $temp_folder
 required_upgrade_name="v2.2.0" # CHANGE THIS
 upgrade_binary_url="https://github.com/lavanet/lava/releases/download/$required_upgrade_name/lavad-$required_upgrade_name-linux-amd64"
 ```
+
 
 2. Kill all current lavad processes
 
@@ -241,7 +253,7 @@ sudo journalctl -u lavad -f
 ## Welcome to Lava Mainnet 🌋
 
 :::tip Joined Mainnet? Be a validator!
-You are now running a Node in the Lava network 🎉🥳!
+You are now running a Node in the Lava network 🎉🥳! 
 
 Congrats, happy to have you here 😻 Celebrate it with us on Discord.
 


### PR DESCRIPTION
This PR adds KSYNC to the Lava documentation. This enables Lava validators to state-sync in minutes to the latest live height or block-sync from genesis to live height for full and archival nodes.